### PR TITLE
Added support for Haml

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ ID Support:
 * Command to manually re-cache the class definitions used in the autocompletion
 * User Settings to override which folders and files should be considered or excluded from the caching process
 * Incremental build. You do not need to re-cache everytime.
-* Additional **Slim, Smarty, Eex and Svelte** template support
+* Additional **Slim, Haml, Smarty, Eex and Svelte** template support
 * Both-way `SCSS` support
 * Separate `class` and `id` support **Work in progress.**
-* Automatically parse all remote stylesheets from HTML, Svelte, Twig, Slim and ERB files.
-* HTML, SCSS, SASS, CSS, Elixir, PHP, Vue, Slim, Latte and many more
+* Automatically parse all remote stylesheets from HTML, Svelte, Twig, Slim, Haml, and ERB files.
+* HTML, SCSS, SASS, CSS, Elixir, PHP, Vue, Slim, Haml, Latte and many more
 
 ## Supported Language Modes
 * HTML
@@ -37,6 +37,7 @@ ID Support:
 * Twig
 * Smarty (.tpl)
 * Slim [requires [Slim](https://marketplace.visualstudio.com/items?itemName=sianglim.slim)]
+* Haml
 * Latte [requires **Latte** extension]
 * Svelte [requires [Svelte](https://marketplace.visualstudio.com/items?itemName=JamesBirtles.svelte-vscode)]
 * Elixir HTML (EEx) and HTML (Eex)
@@ -121,7 +122,7 @@ When we include Template files to show usages, IntelliSense can be **very** slow
 
 Emmet support comes disabled by default, the reason behind this choice is because it the current implementation simply triggers completion when you type a "." (period) and this behavior might be considered a little annoying, but it might change in the future.
 
-Currently it supports the following languages (those are [language identifier](https://code.visualstudio.com/docs/languages/identifiers#_known-language-identifiers)): "html", "eex", "latte", "razor", "php", "blade", "vue", "twig", "markdown", "erb", "handlebars", "ejs", "slim", "typescriptreact", "javascript", "javascriptreact".
+Currently it supports the following languages (those are [language identifier](https://code.visualstudio.com/docs/languages/identifiers#_known-language-identifiers)): "html", "eex", "latte", "razor", "php", "blade", "vue", "twig", "markdown", "erb", "handlebars", "ejs", "slim", "haml", "typescriptreact", "javascript", "javascriptreact".
 
 * `"html-css-class-completion.enableEmmetSupport"` (default: `false`)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "html-slim-scss-css-class-completion",
   "displayName": "SCSS Everywhere",
-  "description": ":class and :id completion for HTML, Svelte, Latte, Slim, Elixir, Smarty, PHP, ERB, Javascript, CSS and SCSS. Just declare class in your template or CSS/SCSS and see it in everywhere. (Both directions)",
+  "description": ":class and :id completion for HTML, Svelte, Latte, Slim, Haml, Elixir, Smarty, PHP, ERB, Javascript, CSS and SCSS. Just declare class in your template or CSS/SCSS and see it in everywhere. (Both directions)",
   "version": "1.7.4",
   "publisher": "gencer",
   "engines": {
@@ -10,6 +10,7 @@
   "keywords": [
     "html",
     "slim",
+    "haml",
     "scss",
     "css",
     "eex",
@@ -35,7 +36,7 @@
         "properties": {
           "html-css-class-completion.includeGlobPattern": {
             "type": "string",
-            "default": "**/*.{css,scss,sass,eex,slim,svelte,tpl,latte,php,html,twig}",
+            "default": "**/*.{css,scss,sass,eex,slim,haml,svelte,tpl,latte,php,html,twig}",
             "description": "A glob pattern that defines files and folders to search for. The glob pattern will be matched against the paths of resulting matches relative to their workspace."
           },
           "html-css-class-completion.searchRemoteGlobPattern": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -38,7 +38,7 @@ let selectors: ISelectorObject = {};
 
 let definitions: CssClassDefinition[] = [];
 const emmetDisposables: Array<{ dispose(): any }> = [];
-const searchForIn: string[] = [".latte", ".twig", ".tpl", ".html", ".slim", ".php", ".scss"];
+const searchForIn: string[] = [".latte", ".twig", ".tpl", ".html", ".slim", ".haml", ".php", ".scss"];
 
 // hack into it
 function endsWithAny(suffixes: string[], str: string) {
@@ -208,7 +208,9 @@ function provideCompletionItemsGenerator(languageSelector: string, classMatchReg
             const rawClasses: RegExpMatchArray = text.match(classMatchRegex);
             const excluded: RegExpMatchArray = text.match(/[\"\(\{]/);
             if (!rawClasses || rawClasses.length === 1 ||
-                (languageSelector === "slim" && excluded != null && !text.endsWith("class=\""))) {
+                (
+                    (languageSelector === "slim" || languageSelector === "haml") && 
+                    excluded != null && !text.endsWith("class=\""))) {
                 return [];
             }
 
@@ -276,7 +278,7 @@ function provideCompletionItemsGenerator(languageSelector: string, classMatchReg
 
 function enableEmmetSupport(disposables: Disposable[]) {
     const emmetRegex = /(?=\.)([\w-\. ]*$)/;
-    const languageModes = ["slim", "HTML (Eex)", "HTML (EEx)", "eex", "svelte", "html", "razor", "php", "latte", "smarty", "blade", "vue", "twig", "markdown", "erb",
+    const languageModes = ["slim", "haml", "HTML (Eex)", "HTML (EEx)", "eex", "svelte", "html", "razor", "php", "latte", "smarty", "blade", "vue", "twig", "markdown", "erb",
         "handlebars", "ejs", "typescriptreact", "javascript", "javascriptreact", "scss", "sass", "css"];
     languageModes.forEach((language) => {
         emmetDisposables.push(provideCompletionItemsGenerator(language, emmetRegex, "", "."));
@@ -292,7 +294,7 @@ function disableEmmetSupport(disposables: Disposable[]) {
 export async function activate(context: ExtensionContext): Promise<void> {
     const disposables: Disposable[] = [];
     const onSave = vscode.workspace.onDidSaveTextDocument((e: vscode.TextDocument) => {
-        if (["twig", "erb", "eex", "HTML (EEx)", "HTML (Eex)", "html", "latte", "smarty", "slim", "xhtml", "css", "scss"].indexOf(e.languageId) > -1) {
+        if (["twig", "erb", "eex", "HTML (EEx)", "HTML (Eex)", "html", "latte", "smarty", "slim", "haml", "xhtml", "css", "scss"].indexOf(e.languageId) > -1) {
             cache([e.uri], true);
         }
     });
@@ -343,13 +345,13 @@ export async function activate(context: ExtensionContext): Promise<void> {
 
     // HTML based extensions
     // tslint:disable-next-line:max-line-length
-    ["slim", "html", "svelte", "eex", "HTML (EEx)", "HTML (Eex)", "latte", "smarty", "razor", "php", "blade", "vue", "twig", "markdown", "erb", "handlebars", "ejs"].forEach((extension) => {
+    ["slim", "haml", "html", "svelte", "eex", "HTML (EEx)", "HTML (Eex)", "latte", "smarty", "razor", "php", "blade", "vue", "twig", "markdown", "erb", "handlebars", "ejs"].forEach((extension) => {
         context.subscriptions.push(provideCompletionItemsGenerator(extension, /(class|className)=["|']([^"^']*$)/i));
         context.subscriptions.push(provideCompletionItemsGenerator(extension, /(id)=["|']([^"^']*$)/i, "#"));
     });
 
     // SLIM based extensions
-    ["slim"].forEach((extension) => {
+    ["slim", "haml"].forEach((extension) => {
         // tslint:disable-next-line:max-line-length
         context.subscriptions.push(provideCompletionItemsGenerator(extension, /(\#|\.)[^\s]*$/i, ""));
         context.subscriptions.push(provideCompletionItemsGenerator(extension, /(\B#\S+)[^\s]*$/i, "#"));

--- a/src/parse-engines/common/haml-class-extractor.ts
+++ b/src/parse-engines/common/haml-class-extractor.ts
@@ -1,0 +1,22 @@
+import * as vscode from "vscode";
+
+import CssClassDefinition from "../../common/css-class-definition";
+
+export default class HamlClassExtractor {
+    /**
+     * @description Extracts class names from CSS AST
+     */
+    public static extract(scss: string): CssClassDefinition[] {
+        const classNameRegex: RegExp = /[.|\#]-?[_a-zA-Z]+[_a-zA-Z0-9-]*(?=(?:(?:[^"']*"[^"']*")|(?:[^'"]*'[^'"]*'))*[^"']*$)/g;
+
+        const definitions: CssClassDefinition[] = [];
+
+        let item: RegExpExecArray = classNameRegex.exec(scss);
+        while (item) {
+            definitions.push(new CssClassDefinition(item[0]));
+            item = classNameRegex.exec(scss);
+        }
+
+        return definitions;
+    }
+}

--- a/src/parse-engines/parse-engine-registry copy.ts
+++ b/src/parse-engines/parse-engine-registry copy.ts
@@ -6,6 +6,7 @@ import LatteParseEngine from "./types/latte-parse-engine";
 import PhpParseEngine from "./types/php-parse-engine";
 import ScssParseEngine from "./types/scss-parse-engine";
 import SlimParseEngine from "./types/slim-parse-engine";
+import HamlParseEngine from "./types/haml-parse-engine";
 import EexParseEngine from "./types/eex-parse-engine";
 import SvelteParseEngine from "./types/svelte-parse-engine";
 import SmartyParseEngine from "./types/smarty-parse-engine";
@@ -43,6 +44,7 @@ class ParseEngineRegistry {
         new ScssParseEngine(),
         new HtmlParseEngine(),
         new SlimParseEngine(),
+        new HamlParseEngine(),
         new PhpParseEngine(),
     ];
 }

--- a/src/parse-engines/parse-engine-registry.ts
+++ b/src/parse-engines/parse-engine-registry.ts
@@ -6,6 +6,7 @@ import LatteParseEngine from "./types/latte-parse-engine";
 import PhpParseEngine from "./types/php-parse-engine";
 import ScssParseEngine from "./types/scss-parse-engine";
 import SlimParseEngine from "./types/slim-parse-engine";
+import HamlParseEngine from "./types/haml-parse-engine";
 import EexParseEngine from "./types/eex-parse-engine";
 import SvelteParseEngine from "./types/svelte-parse-engine";
 import SmartyParseEngine from "./types/smarty-parse-engine";
@@ -41,6 +42,7 @@ class ParseEngineRegistry {
         new ScssParseEngine(),
         new HtmlParseEngine(),
         new SlimParseEngine(),
+        new HamlParseEngine(),
         new PhpParseEngine(),
     ];
 }

--- a/src/parse-engines/types/haml-parse-engine.ts
+++ b/src/parse-engines/types/haml-parse-engine.ts
@@ -1,0 +1,17 @@
+import * as vscode from "vscode";
+import CssClassDefinition from "../../common/css-class-definition";
+import IParseEngine from "../common/parse-engine";
+import ISimpleTextDocument from "../common/simple-text-document";
+import HamlClassExtractor from "../common/haml-class-extractor";
+
+class HamlParseEngine implements IParseEngine {
+    public languageId: string = "haml";
+    public extension: string = "haml";
+
+    public async parse(textDocument: ISimpleTextDocument): Promise<CssClassDefinition[]> {
+        const code: string = textDocument.getText().replace(/\/\*[\s\S]*?\*\/|([^:]|^)\/\/.*$/gm, "");
+        return HamlClassExtractor.extract(code);
+    }
+}
+
+export default HamlParseEngine;


### PR DESCRIPTION
It was really easy to get this working, since Haml is so similar to Slim. I just copied/pasted all of the Slim code and renamed it to Haml, and it worked out of the box for all the basic cases. (But I still think it's a good idea to duplicate the code in case there are some edge cases that need to be fixed in the future.)

<img width="653" alt="Screen Shot 2020-05-03 at 8 11 27 PM" src="https://user-images.githubusercontent.com/139536/80913843-46b4c500-8d7a-11ea-9a65-4008e02a735b.png">
